### PR TITLE
gh-16 Add support for Wildfly Maven plugin

### DIFF
--- a/jboss-as7/README.md
+++ b/jboss-as7/README.md
@@ -55,6 +55,10 @@ refer to the [Getting Started Guide](https://docs.jboss.org/author/display/ISPN/
     * `mvn -Pdomain-distributed jboss-as:add-resource` for a distributed cache
 * To deploy the application use `mvn clean package jboss-as:deploy`
 
+### Use the Wildfly Maven plugin
+
+* To deploy the application use `mvn clean package wildfly:deploy`
+
 ### Quick testing data-grid in domain mode
 
 This quick start ships a .cli script in the root folder that automatically applies the AS7 container changes required to get the domain part of the quick start running. To run this script:

--- a/jboss-as7/pom.xml
+++ b/jboss-as7/pom.xml
@@ -147,6 +147,13 @@
             <version>7.1.1.Final</version>
          </plugin>
 
+         <!-- Wildfly plugin to deploy war -->
+         <plugin>
+            <groupId>org.wildfly.plugins</groupId>
+            <artifactId>wildfly-maven-plugin</artifactId>
+            <version>1.0.2.Final</version>
+         </plugin>
+
          <!-- Compiler plugin enforces Java 1.6 compatibility and activates
             annotation processors -->
          <plugin>

--- a/jboss-as7/src/main/webapp/WEB-INF/web.xml
+++ b/jboss-as7/src/main/webapp/WEB-INF/web.xml
@@ -29,9 +29,4 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
     version="3.0">
 
-    <context-param>
-        <param-name>javax.faces.STATE_SAVING_METHOD</param-name>
-        <param-value>client</param-value>
-    </context-param>
-
 </web-app>


### PR DESCRIPTION
- Works with Wildfly 8.1 and 9.0.0.Alpha1.
- Removed Client JSF state saving section, which causes deployment exception "Unable to find the encoded key.: javax.naming.NameNotFoundException: env/jsf/ClientSideSecretKey".
